### PR TITLE
Make tag a string instead of a number

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: garland/kubernetes-fluentd-loggly
-  tag: 1.0 
+  tag: "1.0" 
   pullPolicy: IfNotPresent
 loggly:
   url: https://logs-01.loggly.com/inputs/my-access-token/tag/k8s


### PR DESCRIPTION
The tag was rendered as "1" in the template instead of the expected "1.0", causing an image pull error.